### PR TITLE
Fixed problem with categorical nodes.

### DIFF
--- a/R/simulation.r
+++ b/R/simulation.r
@@ -97,7 +97,7 @@ simFromDAG <- function(DAG, Nsamp, wide = TRUE, LTCF = NULL, rndseed = NULL, rnd
       # print("distparam: "); print(distparam)
       # print("class(distparam): "); print(class(distparam))
 
-      if (class(distparam)%in%"list") {
+      if (is(distparam,"list")) {
         distparam <- lapply(distparam, check_len)
         distparam <- do.call("cbind", distparam)
       } else if (is.vector(distparam)) {

--- a/vignettes/simcausal_vignette.Rnw
+++ b/vignettes/simcausal_vignette.Rnw
@@ -2,7 +2,7 @@
 % \documentclass[a4paper]{article}
 % \documentclass[article,nojss]{jss}
 % alternative:
-\documentclass[nojss,article,shortnames]{jss}
+\documentclass[nojss,article,shortnames,table]{jss}
 % \usepackage[margin=2.5cm]{geometry}
 \usepackage{float}
 \usepackage{amssymb,amsmath,amsfonts}
@@ -10,7 +10,7 @@
 \usepackage[multiple]{footmisc}
 \usepackage[utf8]{inputenc}
 % \usepackage[colorlinks=true,urlcolor=blue]{hyperref}
-% \usepackage{graphicx}
+\usepackage{graphicx}
 % \usepackage[font={scriptsize, it}]{caption}
 \usepackage[english]{babel}
 \usepackage{pdflscape}
@@ -19,7 +19,7 @@
 % \usepackage{color}
 
 % causes conflict with jss style:
-% \usepackage[table]{xcolor}
+\usepackage[]{xcolor}
 % \usepackage[]{colortbl}
 % \usepackage{listings}
 % \lstset{breaklines=true}


### PR DESCRIPTION
It appears the current version of R sends error if the argument of a "if" function is a vector. This was causing an error when building the vignette. In fact In the current version it is not possible to set a DAG with categorical node.

