### PR TITLE
refactor: use .from() instead of deprecated from() from igraph

### DIFF
--- a/R/simcausal.r
+++ b/R/simcausal.r
@@ -421,7 +421,7 @@ plotDAG <- function(DAG, tmax = NULL, xjitter, yjitter, node.action.color, verte
     igraph::V(g)[igraph::V(g)$name%in%latent.v]$shape <- "circle"
     # igraph::E(g)[from(igraph::V(g)[igraph::V(g)$name%in%latent.v])]$lty <- 2 # dashed
     # to prevent a NOTE from using undeclared global "from" in igraph indexing
-    Eg.sel <- eval(parse(text="igraph::E(g)[from(igraph::V(g)[igraph::V(g)$name%in%latent.v])]$lty <- 5")) # long dash
+    Eg.sel <- eval(parse(text="igraph::E(g)[.from(igraph::V(g)[igraph::V(g)$name%in%latent.v])]$lty <- 5")) # long dash
   }
   # use user-supplied custom labels for DAG nodes:
   if (!missing(customvlabs)) {


### PR DESCRIPTION
:wave: @osofr! I'm opening this PR on behalf of the igraph R package team as we prepare the next release of igraph. The `from()` function is being hard-deprecated.